### PR TITLE
Changed pod into deployment

### DIFF
--- a/provision-cbci-pipeline-workshop
+++ b/provision-cbci-pipeline-workshop
@@ -26,20 +26,31 @@ pipeline {
         kubernetes {
           label 'kubectl'
           yaml """
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: kubectl
 spec:
-  serviceAccountName: jenkins
-  containers:
-  - name: kubectl
-    image: gcr.io/cloud-builders/kubectl
-    resources:
-      requests:
-        memory: "500Mi"
-    command:
-    - cat
-    tty: true 
+  replicas: 4
+  selector:
+    matchLabels:
+      name: kubectl
+  template:
+    metadata:
+      name: kubectl
+      labels:
+        name: kubectl
+    spec:
+      serviceAccountName: jenkins
+      containers:
+      - name: kubectl
+        image: gcr.io/cloud-builders/kubectl
+        resources:
+          requests:
+            memory: "500Mi"
+        command:
+        - cat
+        tty: true 
           """
         }
       }


### PR DESCRIPTION
The issues I discovered while aiding Elena M. with her demo were all (3) k8s errors from the CBCI stdout. When too many requests are routed to the pod at the same time this will cause failure to launch controllers during the workshop. If this solution works we should see less controllers with init failures. Currently we are just having SAs start/stop(restart) failed controllers during labs to get them up for attendees.