### PR TITLE
update cbci.yml

### DIFF
--- a/kubernetes-provisioning/helm/cbci.yml
+++ b/kubernetes-provisioning/helm/cbci.yml
@@ -162,7 +162,7 @@ OperationsCenter:
     Class: nginx
     # OperationsCenter.Ingress.Annotations -- annotations to put on Ingress object
     Annotations:
-      kubernetes.io/ingress.class: nginx
+      # kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: 'true'
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
 


### PR DESCRIPTION
can not be set when the class field is also set at annotations.kubernetes.io/ingress.class: Invalid value: "nginx":